### PR TITLE
Adds support for free-format client-generated IDs

### DIFF
--- a/src/Examples/GettingStarted/Models/Book.cs
+++ b/src/Examples/GettingStarted/Models/Book.cs
@@ -5,7 +5,7 @@ using JsonApiDotNetCore.Resources.Annotations;
 namespace GettingStarted.Models
 {
     [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-    public sealed class Book : MongoIdentifiable
+    public sealed class Book : MongoObjectIdentifiable
     {
         [Attr]
         public string Title { get; set; }

--- a/src/Examples/JsonApiDotNetCoreMongoDbExample/Models/TodoItem.cs
+++ b/src/Examples/JsonApiDotNetCoreMongoDbExample/Models/TodoItem.cs
@@ -6,7 +6,7 @@ using JsonApiDotNetCore.Resources.Annotations;
 namespace JsonApiDotNetCoreMongoDbExample.Models
 {
     [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-    public sealed class TodoItem : MongoIdentifiable
+    public sealed class TodoItem : MongoObjectIdentifiable
     {
         [Attr]
         public string Description { get; set; }

--- a/src/JsonApiDotNetCore.MongoDb/Resources/IMongoIdentifiable.cs
+++ b/src/JsonApiDotNetCore.MongoDb/Resources/IMongoIdentifiable.cs
@@ -1,0 +1,11 @@
+using JsonApiDotNetCore.Resources;
+
+namespace JsonApiDotNetCore.MongoDb.Resources
+{
+    /// <summary>
+    /// Marker interface to indicate a resource that is stored in MongoDB.
+    /// </summary>
+    public interface IMongoIdentifiable : IIdentifiable<string>
+    {
+    }
+}

--- a/src/JsonApiDotNetCore.MongoDb/Resources/MongoObjectIdentifiable.cs
+++ b/src/JsonApiDotNetCore.MongoDb/Resources/MongoObjectIdentifiable.cs
@@ -1,0 +1,28 @@
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace JsonApiDotNetCore.MongoDb.Resources
+{
+    /// <summary>
+    /// Basic implementation of a JSON:API resource whose Id is stored as a 12-byte hexadecimal ObjectId in MongoDB.
+    /// </summary>
+    public abstract class MongoObjectIdentifiable : IMongoIdentifiable
+    {
+        /// <inheritdoc />
+        [BsonId]
+        [BsonRepresentation(BsonType.ObjectId)]
+        public virtual string Id { get; set; }
+
+        /// <inheritdoc />
+        [BsonIgnore]
+        public string StringId
+        {
+            get => Id;
+            set => Id = value;
+        }
+
+        /// <inheritdoc />
+        [BsonIgnore]
+        public string LocalId { get; set; }
+    }
+}

--- a/src/JsonApiDotNetCore.MongoDb/Resources/MongoStringIdentifiable.cs
+++ b/src/JsonApiDotNetCore.MongoDb/Resources/MongoStringIdentifiable.cs
@@ -1,17 +1,16 @@
-using JsonApiDotNetCore.Resources;
-using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
+using MongoDB.Bson.Serialization.IdGenerators;
 
 namespace JsonApiDotNetCore.MongoDb.Resources
 {
     /// <summary>
-    /// A convenient basic implementation of <see cref="IIdentifiable" /> for use with MongoDB models.
+    /// Basic implementation of a JSON:API resource whose Id is stored as a free-format string in MongoDB.
+    /// Intended for resources that are created using client-generated IDs.
     /// </summary>
-    public abstract class MongoIdentifiable : IIdentifiable<string>
+    public abstract class MongoStringIdentifiable : IMongoIdentifiable
     {
         /// <inheritdoc />
-        [BsonId]
-        [BsonRepresentation(BsonType.ObjectId)]
+        [BsonId(IdGenerator = typeof(StringObjectIdGenerator))]
         public virtual string Id { get; set; }
 
         /// <inheritdoc />

--- a/src/JsonApiDotNetCore.MongoDb/Resources/MongoStringIdentifiable.cs
+++ b/src/JsonApiDotNetCore.MongoDb/Resources/MongoStringIdentifiable.cs
@@ -4,8 +4,8 @@ using MongoDB.Bson.Serialization.IdGenerators;
 namespace JsonApiDotNetCore.MongoDb.Resources
 {
     /// <summary>
-    /// Basic implementation of a JSON:API resource whose Id is stored as a free-format string in MongoDB.
-    /// Intended for resources that are created using client-generated IDs.
+    /// Basic implementation of a JSON:API resource whose Id is stored as a free-format string in MongoDB. Intended for resources that are created using
+    /// client-generated IDs.
     /// </summary>
     public abstract class MongoStringIdentifiable : IMongoIdentifiable
     {

--- a/src/JsonApiDotNetCore.MongoDb/Serialization/Building/IgnoreRelationshipsResponseResourceObjectBuilder.cs
+++ b/src/JsonApiDotNetCore.MongoDb/Serialization/Building/IgnoreRelationshipsResponseResourceObjectBuilder.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using JsonApiDotNetCore.Configuration;
 using JsonApiDotNetCore.MongoDb.Resources;
 using JsonApiDotNetCore.Queries;
@@ -22,7 +22,7 @@ namespace JsonApiDotNetCore.MongoDb.Serialization.Building
         /// <inheritdoc />
         protected override RelationshipEntry GetRelationshipData(RelationshipAttribute relationship, IIdentifiable resource)
         {
-            if (resource is MongoIdentifiable)
+            if (resource is IMongoIdentifiable)
             {
                 return null;
             }

--- a/test/JsonApiDotNetCoreMongoDbExampleTests/IntegrationTests/AtomicOperations/Creating/AtomicCreateResourceWithClientGeneratedIdTests.cs
+++ b/test/JsonApiDotNetCoreMongoDbExampleTests/IntegrationTests/AtomicOperations/Creating/AtomicCreateResourceWithClientGeneratedIdTests.cs
@@ -32,7 +32,7 @@ namespace JsonApiDotNetCoreMongoDbExampleTests.IntegrationTests.AtomicOperations
         {
             // Arrange
             TextLanguage newLanguage = _fakers.TextLanguage.Generate();
-            newLanguage.Id = "507f191e810c19729de860ea";
+            newLanguage.Id = "free-format-client-generated-id";
 
             await _testContext.RunOnDatabaseAsync(async db =>
             {
@@ -88,7 +88,7 @@ namespace JsonApiDotNetCoreMongoDbExampleTests.IntegrationTests.AtomicOperations
         {
             // Arrange
             MusicTrack newTrack = _fakers.MusicTrack.Generate();
-            newTrack.Id = "5ffcc0d1d69a27c92b8c62dd";
+            newTrack.Id = "free-format-client-generated-id";
 
             await _testContext.RunOnDatabaseAsync(async db =>
             {

--- a/test/JsonApiDotNetCoreMongoDbExampleTests/IntegrationTests/AtomicOperations/Lyric.cs
+++ b/test/JsonApiDotNetCoreMongoDbExampleTests/IntegrationTests/AtomicOperations/Lyric.cs
@@ -7,7 +7,7 @@ using MongoDB.Bson.Serialization.Attributes;
 namespace JsonApiDotNetCoreMongoDbExampleTests.IntegrationTests.AtomicOperations
 {
     [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-    public sealed class Lyric : MongoIdentifiable
+    public sealed class Lyric : MongoObjectIdentifiable
     {
         [Attr]
         public string Format { get; set; }

--- a/test/JsonApiDotNetCoreMongoDbExampleTests/IntegrationTests/AtomicOperations/MusicTrack.cs
+++ b/test/JsonApiDotNetCoreMongoDbExampleTests/IntegrationTests/AtomicOperations/MusicTrack.cs
@@ -9,7 +9,7 @@ using MongoDB.Bson.Serialization.Attributes;
 namespace JsonApiDotNetCoreMongoDbExampleTests.IntegrationTests.AtomicOperations
 {
     [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-    public sealed class MusicTrack : MongoIdentifiable
+    public sealed class MusicTrack : MongoStringIdentifiable
     {
         [RegularExpression(@"(?im)^[{(]?[0-9A-F]{8}[-]?(?:[0-9A-F]{4}[-]?){3}[0-9A-F]{12}[)}]?$")]
         public override string Id { get; set; }

--- a/test/JsonApiDotNetCoreMongoDbExampleTests/IntegrationTests/AtomicOperations/Performer.cs
+++ b/test/JsonApiDotNetCoreMongoDbExampleTests/IntegrationTests/AtomicOperations/Performer.cs
@@ -6,7 +6,7 @@ using JsonApiDotNetCore.Resources.Annotations;
 namespace JsonApiDotNetCoreMongoDbExampleTests.IntegrationTests.AtomicOperations
 {
     [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-    public sealed class Performer : MongoIdentifiable
+    public sealed class Performer : MongoObjectIdentifiable
     {
         [Attr]
         public string ArtistName { get; set; }

--- a/test/JsonApiDotNetCoreMongoDbExampleTests/IntegrationTests/AtomicOperations/Playlist.cs
+++ b/test/JsonApiDotNetCoreMongoDbExampleTests/IntegrationTests/AtomicOperations/Playlist.cs
@@ -8,7 +8,7 @@ using MongoDB.Bson.Serialization.Attributes;
 namespace JsonApiDotNetCoreMongoDbExampleTests.IntegrationTests.AtomicOperations
 {
     [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-    public sealed class Playlist : MongoIdentifiable
+    public sealed class Playlist : MongoObjectIdentifiable
     {
         [Attr]
         [Required]

--- a/test/JsonApiDotNetCoreMongoDbExampleTests/IntegrationTests/AtomicOperations/RecordCompany.cs
+++ b/test/JsonApiDotNetCoreMongoDbExampleTests/IntegrationTests/AtomicOperations/RecordCompany.cs
@@ -7,7 +7,7 @@ using MongoDB.Bson.Serialization.Attributes;
 namespace JsonApiDotNetCoreMongoDbExampleTests.IntegrationTests.AtomicOperations
 {
     [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-    public sealed class RecordCompany : MongoIdentifiable
+    public sealed class RecordCompany : MongoObjectIdentifiable
     {
         [Attr]
         public string Name { get; set; }

--- a/test/JsonApiDotNetCoreMongoDbExampleTests/IntegrationTests/AtomicOperations/TextLanguage.cs
+++ b/test/JsonApiDotNetCoreMongoDbExampleTests/IntegrationTests/AtomicOperations/TextLanguage.cs
@@ -8,7 +8,7 @@ using MongoDB.Bson.Serialization.Attributes;
 namespace JsonApiDotNetCoreMongoDbExampleTests.IntegrationTests.AtomicOperations
 {
     [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-    public sealed class TextLanguage : MongoIdentifiable
+    public sealed class TextLanguage : MongoStringIdentifiable
     {
         [Attr]
         public string IsoCode { get; set; }

--- a/test/JsonApiDotNetCoreMongoDbExampleTests/IntegrationTests/Meta/SupportTicket.cs
+++ b/test/JsonApiDotNetCoreMongoDbExampleTests/IntegrationTests/Meta/SupportTicket.cs
@@ -5,7 +5,7 @@ using JsonApiDotNetCore.Resources.Annotations;
 namespace JsonApiDotNetCoreMongoDbExampleTests.IntegrationTests.Meta
 {
     [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-    public sealed class SupportTicket : MongoIdentifiable
+    public sealed class SupportTicket : MongoObjectIdentifiable
     {
         [Attr]
         public string Description { get; set; }

--- a/test/JsonApiDotNetCoreMongoDbExampleTests/IntegrationTests/QueryStrings/AccountPreferences.cs
+++ b/test/JsonApiDotNetCoreMongoDbExampleTests/IntegrationTests/QueryStrings/AccountPreferences.cs
@@ -5,7 +5,7 @@ using JsonApiDotNetCore.Resources.Annotations;
 namespace JsonApiDotNetCoreMongoDbExampleTests.IntegrationTests.QueryStrings
 {
     [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-    public sealed class AccountPreferences : MongoIdentifiable
+    public sealed class AccountPreferences : MongoObjectIdentifiable
     {
         [Attr]
         public bool UseDarkTheme { get; set; }

--- a/test/JsonApiDotNetCoreMongoDbExampleTests/IntegrationTests/QueryStrings/Appointment.cs
+++ b/test/JsonApiDotNetCoreMongoDbExampleTests/IntegrationTests/QueryStrings/Appointment.cs
@@ -6,7 +6,7 @@ using JsonApiDotNetCore.Resources.Annotations;
 namespace JsonApiDotNetCoreMongoDbExampleTests.IntegrationTests.QueryStrings
 {
     [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-    public sealed class Appointment : MongoIdentifiable
+    public sealed class Appointment : MongoObjectIdentifiable
     {
         [Attr]
         public string Title { get; set; }

--- a/test/JsonApiDotNetCoreMongoDbExampleTests/IntegrationTests/QueryStrings/Blog.cs
+++ b/test/JsonApiDotNetCoreMongoDbExampleTests/IntegrationTests/QueryStrings/Blog.cs
@@ -8,7 +8,7 @@ using MongoDB.Bson.Serialization.Attributes;
 namespace JsonApiDotNetCoreMongoDbExampleTests.IntegrationTests.QueryStrings
 {
     [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-    public sealed class Blog : MongoIdentifiable
+    public sealed class Blog : MongoObjectIdentifiable
     {
         [Attr]
         public string Title { get; set; }

--- a/test/JsonApiDotNetCoreMongoDbExampleTests/IntegrationTests/QueryStrings/BlogPost.cs
+++ b/test/JsonApiDotNetCoreMongoDbExampleTests/IntegrationTests/QueryStrings/BlogPost.cs
@@ -7,7 +7,7 @@ using MongoDB.Bson.Serialization.Attributes;
 namespace JsonApiDotNetCoreMongoDbExampleTests.IntegrationTests.QueryStrings
 {
     [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-    public sealed class BlogPost : MongoIdentifiable
+    public sealed class BlogPost : MongoObjectIdentifiable
     {
         [Attr]
         public string Caption { get; set; }

--- a/test/JsonApiDotNetCoreMongoDbExampleTests/IntegrationTests/QueryStrings/Calendar.cs
+++ b/test/JsonApiDotNetCoreMongoDbExampleTests/IntegrationTests/QueryStrings/Calendar.cs
@@ -7,7 +7,7 @@ using MongoDB.Bson.Serialization.Attributes;
 namespace JsonApiDotNetCoreMongoDbExampleTests.IntegrationTests.QueryStrings
 {
     [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-    public sealed class Calendar : MongoIdentifiable
+    public sealed class Calendar : MongoObjectIdentifiable
     {
         [Attr]
         public string TimeZone { get; set; }

--- a/test/JsonApiDotNetCoreMongoDbExampleTests/IntegrationTests/QueryStrings/Comment.cs
+++ b/test/JsonApiDotNetCoreMongoDbExampleTests/IntegrationTests/QueryStrings/Comment.cs
@@ -7,7 +7,7 @@ using MongoDB.Bson.Serialization.Attributes;
 namespace JsonApiDotNetCoreMongoDbExampleTests.IntegrationTests.QueryStrings
 {
     [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-    public sealed class Comment : MongoIdentifiable
+    public sealed class Comment : MongoObjectIdentifiable
     {
         [Attr]
         public string Text { get; set; }

--- a/test/JsonApiDotNetCoreMongoDbExampleTests/IntegrationTests/QueryStrings/Filtering/FilterableResource.cs
+++ b/test/JsonApiDotNetCoreMongoDbExampleTests/IntegrationTests/QueryStrings/Filtering/FilterableResource.cs
@@ -8,7 +8,7 @@ using MongoDB.Bson.Serialization.Attributes;
 namespace JsonApiDotNetCoreMongoDbExampleTests.IntegrationTests.QueryStrings.Filtering
 {
     [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-    public sealed class FilterableResource : MongoIdentifiable
+    public sealed class FilterableResource : MongoObjectIdentifiable
     {
         [Attr]
         public string SomeString { get; set; }

--- a/test/JsonApiDotNetCoreMongoDbExampleTests/IntegrationTests/QueryStrings/Label.cs
+++ b/test/JsonApiDotNetCoreMongoDbExampleTests/IntegrationTests/QueryStrings/Label.cs
@@ -7,7 +7,7 @@ using MongoDB.Bson.Serialization.Attributes;
 namespace JsonApiDotNetCoreMongoDbExampleTests.IntegrationTests.QueryStrings
 {
     [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-    public sealed class Label : MongoIdentifiable
+    public sealed class Label : MongoObjectIdentifiable
     {
         [Attr]
         public string Name { get; set; }

--- a/test/JsonApiDotNetCoreMongoDbExampleTests/IntegrationTests/QueryStrings/WebAccount.cs
+++ b/test/JsonApiDotNetCoreMongoDbExampleTests/IntegrationTests/QueryStrings/WebAccount.cs
@@ -8,7 +8,7 @@ using MongoDB.Bson.Serialization.Attributes;
 namespace JsonApiDotNetCoreMongoDbExampleTests.IntegrationTests.QueryStrings
 {
     [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-    public sealed class WebAccount : MongoIdentifiable
+    public sealed class WebAccount : MongoObjectIdentifiable
     {
         [Attr]
         public string UserName { get; set; }

--- a/test/JsonApiDotNetCoreMongoDbExampleTests/IntegrationTests/ReadWrite/Creating/CreateResourceWithClientGeneratedIdTests.cs
+++ b/test/JsonApiDotNetCoreMongoDbExampleTests/IntegrationTests/ReadWrite/Creating/CreateResourceWithClientGeneratedIdTests.cs
@@ -31,7 +31,7 @@ namespace JsonApiDotNetCoreMongoDbExampleTests.IntegrationTests.ReadWrite.Creati
         {
             // Arrange
             RgbColor newColor = _fakers.RgbColor.Generate();
-            newColor.Id = "507f191e810c19729de860ea";
+            newColor.Id = "free-format-client-generated-id";
 
             var requestBody = new
             {
@@ -72,7 +72,7 @@ namespace JsonApiDotNetCoreMongoDbExampleTests.IntegrationTests.ReadWrite.Creati
         {
             // Arrange
             WorkItemGroup newGroup = _fakers.WorkItemGroup.Generate();
-            newGroup.Id = "5ffcc0d1d69a27c92b8c62dd";
+            newGroup.Id = "free-format-client-generated-id";
 
             var requestBody = new
             {

--- a/test/JsonApiDotNetCoreMongoDbExampleTests/IntegrationTests/ReadWrite/RgbColor.cs
+++ b/test/JsonApiDotNetCoreMongoDbExampleTests/IntegrationTests/ReadWrite/RgbColor.cs
@@ -6,7 +6,7 @@ using MongoDB.Bson.Serialization.Attributes;
 namespace JsonApiDotNetCoreMongoDbExampleTests.IntegrationTests.ReadWrite
 {
     [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-    public sealed class RgbColor : MongoIdentifiable
+    public sealed class RgbColor : MongoStringIdentifiable
     {
         [Attr]
         public string DisplayName { get; set; }

--- a/test/JsonApiDotNetCoreMongoDbExampleTests/IntegrationTests/ReadWrite/UserAccount.cs
+++ b/test/JsonApiDotNetCoreMongoDbExampleTests/IntegrationTests/ReadWrite/UserAccount.cs
@@ -7,7 +7,7 @@ using MongoDB.Bson.Serialization.Attributes;
 namespace JsonApiDotNetCoreMongoDbExampleTests.IntegrationTests.ReadWrite
 {
     [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-    public sealed class UserAccount : MongoIdentifiable
+    public sealed class UserAccount : MongoObjectIdentifiable
     {
         [Attr]
         public string FirstName { get; set; }

--- a/test/JsonApiDotNetCoreMongoDbExampleTests/IntegrationTests/ReadWrite/WorkItem.cs
+++ b/test/JsonApiDotNetCoreMongoDbExampleTests/IntegrationTests/ReadWrite/WorkItem.cs
@@ -8,7 +8,7 @@ using MongoDB.Bson.Serialization.Attributes;
 namespace JsonApiDotNetCoreMongoDbExampleTests.IntegrationTests.ReadWrite
 {
     [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-    public sealed class WorkItem : MongoIdentifiable
+    public sealed class WorkItem : MongoObjectIdentifiable
     {
         [Attr]
         public string Description { get; set; }

--- a/test/JsonApiDotNetCoreMongoDbExampleTests/IntegrationTests/ReadWrite/WorkItemGroup.cs
+++ b/test/JsonApiDotNetCoreMongoDbExampleTests/IntegrationTests/ReadWrite/WorkItemGroup.cs
@@ -8,7 +8,7 @@ using MongoDB.Bson.Serialization.Attributes;
 namespace JsonApiDotNetCoreMongoDbExampleTests.IntegrationTests.ReadWrite
 {
     [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-    public sealed class WorkItemGroup : MongoIdentifiable
+    public sealed class WorkItemGroup : MongoStringIdentifiable
     {
         [Attr]
         public string Name { get; set; }

--- a/test/JsonApiDotNetCoreMongoDbExampleTests/IntegrationTests/ReadWrite/WorkTag.cs
+++ b/test/JsonApiDotNetCoreMongoDbExampleTests/IntegrationTests/ReadWrite/WorkTag.cs
@@ -5,7 +5,7 @@ using JsonApiDotNetCore.Resources.Annotations;
 namespace JsonApiDotNetCoreMongoDbExampleTests.IntegrationTests.ReadWrite
 {
     [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-    public sealed class WorkTag : MongoIdentifiable
+    public sealed class WorkTag : MongoObjectIdentifiable
     {
         [Attr]
         public string Text { get; set; }

--- a/test/JsonApiDotNetCoreMongoDbExampleTests/IntegrationTests/ResourceDefinitions/CallableResource.cs
+++ b/test/JsonApiDotNetCoreMongoDbExampleTests/IntegrationTests/ResourceDefinitions/CallableResource.cs
@@ -8,7 +8,7 @@ using MongoDB.Bson.Serialization.Attributes;
 namespace JsonApiDotNetCoreMongoDbExampleTests.IntegrationTests.ResourceDefinitions
 {
     [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-    public sealed class CallableResource : MongoIdentifiable
+    public sealed class CallableResource : MongoObjectIdentifiable
     {
         [Attr]
         public string Label { get; set; }

--- a/test/JsonApiDotNetCoreMongoDbExampleTests/TestBuildingBlocks/MongoQueryableExtensions.cs
+++ b/test/JsonApiDotNetCoreMongoDbExampleTests/TestBuildingBlocks/MongoQueryableExtensions.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using JsonApiDotNetCore.Resources;
+using JsonApiDotNetCore.MongoDb.Resources;
 using MongoDB.Driver.Linq;
 
 namespace JsonApiDotNetCoreMongoDbExampleTests.TestBuildingBlocks
@@ -10,7 +10,7 @@ namespace JsonApiDotNetCoreMongoDbExampleTests.TestBuildingBlocks
     {
         public static async Task<TResource> FirstWithIdAsync<TResource, TId>(this IMongoQueryable<TResource> resources, TId id,
             CancellationToken cancellationToken = default)
-            where TResource : IIdentifiable<TId>
+            where TResource : IMongoIdentifiable
         {
             TResource firstOrDefault = await resources.FirstOrDefaultAsync(resource => Equals(resource.Id, id), cancellationToken);
 
@@ -24,7 +24,7 @@ namespace JsonApiDotNetCoreMongoDbExampleTests.TestBuildingBlocks
 
         public static Task<TResource> FirstWithIdOrDefaultAsync<TResource, TId>(this IMongoQueryable<TResource> resources, TId id,
             CancellationToken cancellationToken = default)
-            where TResource : IIdentifiable<TId>
+            where TResource : IMongoIdentifiable
         {
             return resources.FirstOrDefaultAsync(resource => Equals(resource.Id, id), cancellationToken);
         }


### PR DESCRIPTION
Adds support for free-format client-generated IDs, by introducing `MongoStringIdentifiable` side-by-side with `MongoObjectIdentifiable` (formerly `MongoIdentifiable`), both implementing the marker interface `IMongoIdentifiable`.

Based on the work described in #7, I tried to change existing tests for client-generated IDs to use free-format IDs by overwriting the annotations with fluent mappings. But I was unable to overwrite the Id property, because it is defined in base class (override did not help).

@alastairtree @mrnkr I'm curious if you believe this a good solution. I'm very open to feedback, as I'm not using MongoDB myself.

I'll update the docs before merge, but wanted to get this out soon to gather feedback.