### PR TITLE
Update to latest version of EphemeralMongo

### DIFF
--- a/package-versions.props
+++ b/package-versions.props
@@ -2,18 +2,18 @@
   <PropertyGroup>
     <!-- Published dependencies (only update on major version change) -->
     <JsonApiDotNetCoreFrozenVersion>5.6.0</JsonApiDotNetCoreFrozenVersion>
-    <MongoDBDriverFrozenVersion>2.20.0</MongoDBDriverFrozenVersion>
+    <MongoDBDriverFrozenVersion>2.28.0</MongoDBDriverFrozenVersion>
 
     <!-- Non-published dependencies (these are safe to update, won't cause a breaking change) -->
     <BogusVersion>35.5.*</BogusVersion>
     <CoverletVersion>6.0.*</CoverletVersion>
-    <EphemeralMongoVersion>1.1.*</EphemeralMongoVersion>
+    <EphemeralMongoVersion>2.0.*</EphemeralMongoVersion>
     <FluentAssertionsVersion>6.12.*</FluentAssertionsVersion>
     <GitHubActionsTestLoggerVersion>2.3.*</GitHubActionsTestLoggerVersion>
     <InheritDocVersion>2.0.*</InheritDocVersion>
-    <MongoDBDriverVersion>2.27.*</MongoDBDriverVersion>
+    <MongoDBDriverVersion>2.28.*</MongoDBDriverVersion>
     <SourceLinkVersion>8.0.*</SourceLinkVersion>
-    <TestSdkVersion>17.10.*</TestSdkVersion>
+    <TestSdkVersion>17.13.*</TestSdkVersion>
     <XunitVersion>2.8.*</XunitVersion>
   </PropertyGroup>
 

--- a/test/TestBuildingBlocks/MongoRunnerProvider.cs
+++ b/test/TestBuildingBlocks/MongoRunnerProvider.cs
@@ -25,7 +25,6 @@ internal sealed class MongoRunnerProvider
                 {
                     // Single-node replica set mode is required for transaction support in MongoDB.
                     UseSingleNodeReplicaSet = true,
-                    KillMongoProcessesWhenCurrentProcessExits = true,
                     AdditionalArguments = "--quiet"
                 };
 

--- a/test/TestBuildingBlocks/TestBuildingBlocks.csproj
+++ b/test/TestBuildingBlocks/TestBuildingBlocks.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
   </PropertyGroup>
@@ -13,9 +13,9 @@
     <PackageReference Include="Bogus" Version="$(BogusVersion)" />
     <PackageReference Include="coverlet.collector" Version="$(CoverletVersion)" PrivateAssets="All" />
     <PackageReference Include="EphemeralMongo.Core" Version="$(EphemeralMongoVersion)" />
-    <PackageReference Include="EphemeralMongo6.runtime.linux-x64" Version="$(EphemeralMongoVersion)" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
-    <PackageReference Include="EphemeralMongo6.runtime.osx-x64" Version="$(EphemeralMongoVersion)" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
-    <PackageReference Include="EphemeralMongo6.runtime.win-x64" Version="$(EphemeralMongoVersion)" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
+    <PackageReference Include="EphemeralMongo8.runtime.linux-x64" Version="$(EphemeralMongoVersion)" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
+    <PackageReference Include="EphemeralMongo8.runtime.osx-arm64" Version="$(EphemeralMongoVersion)" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
+    <PackageReference Include="EphemeralMongo8.runtime.win-x64" Version="$(EphemeralMongoVersion)" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
     <PackageReference Include="GitHubActionsTestLogger" Version="$(GitHubActionsTestLoggerVersion)" PrivateAssets="All" />
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="$(AspNetCoreVersion)" />


### PR DESCRIPTION
Experimental. This PR updates to the latest version of [EphemeralMongo](https://github.com/asimmon/ephemeral-mongo), which is a fork of [Mongo2Go](https://github.com/Mongo2Go/Mongo2Go).

This version _doesn't_ work with the newer 3.x version of [MongoDB.Driver](https://github.com/mongodb/mongo-csharp-driver). We switched to it in #23 for reasons I don't remember. Mongo2Go is still alive and _does_ support the latest version, so perhaps we should switch back?

Whether we use EphemeralMongo or Mongo2Go, we'll need to take a breaking change by bumping the MongoDB.Driver version that JsonApiDotNetCore takes a dependency on.

#### QUALITY CHECKLIST
- [ ] Changes implemented in code
- [ ] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [ ] Adapted tests
- [ ] Documentation updated
