### PR TITLE
Bump GitHub Actions artefacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -227,7 +227,7 @@ jobs:
     - name: Tune GitHub-hosted runner network
       uses: smorimoto/tune-github-hosted-runner-network@v1
     - name: Download artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
     - name: Publish to GitHub Packages
       if: ${{ github.event_name == 'push' || github.event_name == 'release' }}
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -226,8 +226,11 @@ jobs:
     steps:
     - name: Tune GitHub-hosted runner network
       uses: smorimoto/tune-github-hosted-runner-network@v1
-    - name: Download artifacts
+    - name: Download package artifacts
       uses: actions/download-artifact@v8
+      with:
+        name: packages
+        path: packages
     - name: Publish to GitHub Packages
       if: ${{ github.event_name == 'push' || github.event_name == 'release' }}
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,7 @@ jobs:
       run: dotnet pack --no-build --configuration Release --output ${{ github.workspace }}/artifacts/packages /p:VersionSuffix=${{ env.PACKAGE_VERSION_SUFFIX }}
     - name: Upload packages to artifacts
       if: ${{ matrix.os == 'ubuntu-latest' }}
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       with:
         name: packages
         path: artifacts/packages


### PR DESCRIPTION
Bump upload/download artifacts to the latest versions.
Compensates for the bug at https://github.com/actions/download-artifact/issues/426.
