### PR TITLE
Use Docker Compose to start containers

### DIFF
--- a/JsonApiDotNetCore.MongoDb.slnx
+++ b/JsonApiDotNetCore.MongoDb.slnx
@@ -10,7 +10,10 @@
     <File Path=".gitignore" />
     <File Path="CodingGuidelines.ruleset" />
     <File Path="Directory.Build.props" />
+    <File Path="docker-compose.yml" />
     <File Path="package-versions.props" />
+    <File Path="PackageReadme.md" />
+    <File Path="README.md" />
     <File Path="tests.runsettings" />
   </Folder>
   <Folder Name="/src/">

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,44 @@
+name: jsonapi-mongodb
+
+# This file starts a MongoDB database in a docker container, which is required for running examples locally.
+# It also starts Mongo Express (a web-based MongoDB management tool) in a second container, which lets you query the database.
+#
+# Usage:
+#   docker compose up --detach --wait
+#
+# To connect to Mongo Express, open http://localhost:8081. It will automatically log in and connect to the database.
+#
+# To stop:
+#   docker compose down
+
+services:
+  mongo-db:
+    image: mongo:latest
+    pull_policy: always
+    container_name: jsonapi-mongodb-mongo-db
+    ports:
+      - "27017:27017"
+    healthcheck:
+      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
+      interval: 1s
+      timeout: 3s
+      retries: 15
+      start_period: 2s
+
+  mongo-express:
+    image: mongo-express:latest
+    pull_policy: always
+    container_name: jsonapi-mongodb-mongo-express
+    environment:
+      ME_CONFIG_MONGODB_URL: mongodb://mongo-db:27017
+      ME_CONFIG_BASICAUTH: 'false'
+    ports:
+      - "8081:8081"
+    depends_on:
+      - mongo-db
+    healthcheck:
+      test: ["CMD", "node", "-e", "require('http').get('http://127.0.0.1:8081/status', (r) => { process.exit(r.statusCode === 200 ? 0 : 1); }).on('error', () => process.exit(1));"]
+      interval: 1s
+      timeout: 3s
+      retries: 10
+      start_period: 2s

--- a/run-docker-mongodb.ps1
+++ b/run-docker-mongodb.ps1
@@ -1,6 +1,12 @@
 #Requires -Version 7.0
+$ErrorActionPreference = "Stop"
+$PSNativeCommandUseErrorActionPreference = $true
 
-# This script starts a MongoDB database in a docker container, which is required for running examples locally.
-
-docker container stop jsonapi-mongo-db
-docker run --pull always --rm --detach --name jsonapi-mongo-db -p 27017:27017 mongo:latest
+Push-Location $PSScriptRoot
+try {
+    docker compose down
+    docker compose up --detach --wait
+}
+finally {
+    Pop-Location
+}

--- a/src/Examples/JsonApiDotNetCoreMongoDbExample/JsonApiDotNetCoreMongoDbExample.http
+++ b/src/Examples/JsonApiDotNetCoreMongoDbExample/JsonApiDotNetCoreMongoDbExample.http
@@ -1,0 +1,21 @@
+@hostAddress = https://localhost:44340
+
+### Gets all high-priority todo-items.
+
+GET {{hostAddress}}/api/todoItems?filter=equals(priority,'High')
+
+### Creates a todo-item.
+
+POST {{hostAddress}}/api/todoItems
+Content-Type: application/vnd.api+json
+
+{
+  "data": {
+    "type": "todoItems",
+    "attributes": {
+      "description": "Create release",
+      "priority": "High",
+      "durationInHours": 1
+    }
+  }
+}


### PR DESCRIPTION
Convert Docker commands into `docker-compose.yml` file that auto-logins to web-based database management tool, while waiting until containers are healthy.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [ ] N/A: Adapted tests
- [x] Documentation updated
